### PR TITLE
Add support for the `@describable struct Foo ... end` form of the macro

### DIFF
--- a/test/describables.jl
+++ b/test/describables.jl
@@ -1,13 +1,11 @@
 using Describables: Describables, @describable, show_describable
 
 # Workflow #1: `@describable struct Foo ... end`
-# @describable struct Foo # TODO: uncomment this line
-struct Foo # TODO: delete this line
+@describable struct Foo
     x::Float64
     y::AbstractString
     z::Any
 end
-@describable Foo # TODO: delete this line
 
 # Workflow #2: `@describable Bar`
 struct Bar

--- a/test/describables.jl
+++ b/test/describables.jl
@@ -141,5 +141,12 @@ end
     end
 end
 
+@testset "more code coverage" begin
+    @testset "the @describable macro" begin
+        expected_msg = "Argument must be either a struct definition or a symbol"
+        @test_throws ArgumentError(expected_msg) Describables._describable_macro(:(1 + 1))
+    end
+end
+
 # @testset "type stability" begin
 # end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 import Describables
 import Test
 
-using Test: @testset, @test
+using Test: @testset, @test, @test_throws
 using Test: @inferred
 
 include("describables.jl")


### PR DESCRIPTION
We already support the `@describable Bar` form of the macro.

This PR adds support for the `@describable struct Foo ... end` form, e.g.:

```julia
@describable struct Foo
    x
    y
    z
end
```