### PR TITLE
README: make an example a bit shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ julia> struct Hello
            y
        end
 
-julia> Base.show(io::IO, mime::Base.MIME"text/plain", obj::Hello) = show_describable(io, mime, obj)
+julia> Base.show(io::IO, mime::MIME"text/plain", obj::Hello) = show_describable(io, mime, obj)
 
 julia> Hello(1, 2)
 Hello(1, 2, #=  =#)


### PR DESCRIPTION
`MIME"text/plain" === Base.MIME"text/plain"`, and it looks like `MIME` is exported from Base, so we can replace `Base.MIME` with just `MIME` in this example.